### PR TITLE
fix: resolve all 39 dart analyze warnings

### DIFF
--- a/lib/config/colors.dart
+++ b/lib/config/colors.dart
@@ -12,13 +12,13 @@ mixin AppColors {
 
   static Color get cardBackground =>
       CacheService.settings.darkMode.getValue()
-          ? Colors.white.withOpacity(0.05)
+          ? Colors.white.withValues(alpha: 0.05)
           : Colors.white;
 
   static Color get cardShadowColor =>
       CacheService.settings.darkMode.getValue()
           ? Colors.black26
-          : Colors.grey.withOpacity(0.15);
+          : Colors.grey.withValues(alpha: 0.15);
 
   static LinearGradient get primaryGradient => LinearGradient(
         colors: [primary, secondary],

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -21,7 +21,7 @@ class MyApp extends StatelessWidget {
                 ),
           ),
           primaryColor: AppColors.primary,
-          appBarTheme: AppBarTheme(color: Colors.transparent),
+          appBarTheme: AppBarTheme(backgroundColor: Colors.transparent),
           brightness: Brightness.dark,
           visualDensity: VisualDensity.adaptivePlatformDensity,
         );
@@ -34,7 +34,7 @@ class MyApp extends StatelessWidget {
           primaryColor: AppColors.primary,
           brightness: Brightness.light,
           visualDensity: VisualDensity.adaptivePlatformDensity,
-          appBarTheme: AppBarTheme(color: Colors.transparent),
+          appBarTheme: AppBarTheme(backgroundColor: Colors.transparent),
         );
     return PreferenceBuilder<bool>(
         preference: CacheService.settings.darkMode,

--- a/lib/ui/cta_section.dart
+++ b/lib/ui/cta_section.dart
@@ -10,7 +10,7 @@ class CtaSection extends StatelessWidget {
 
   void _sendMail() async {
     final mailto = Mailto(to: [AppConstants.mail]);
-    await launch('$mailto');
+    await launchUrl(Uri.parse('$mailto'));
   }
 
   @override

--- a/lib/ui/education_view.dart
+++ b/lib/ui/education_view.dart
@@ -12,7 +12,7 @@ class EducationView extends StatelessWidget {
       decoration: BoxDecoration(
         borderRadius: BorderRadius.circular(12),
         border: Border.all(
-          color: AppColors.primary.withOpacity(0.2),
+          color: AppColors.primary.withValues(alpha: 0.2),
         ),
         color: AppColors.cardBackground,
       ),
@@ -23,7 +23,7 @@ class EducationView extends StatelessWidget {
             padding: const EdgeInsets.all(10),
             decoration: BoxDecoration(
               shape: BoxShape.circle,
-              color: AppColors.primary.withOpacity(0.1),
+              color: AppColors.primary.withValues(alpha: 0.1),
             ),
             child: Icon(
               Icons.school_rounded,

--- a/lib/ui/exp_view.dart
+++ b/lib/ui/exp_view.dart
@@ -12,9 +12,7 @@ class ExpView extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: myInfo.exps.asMap().entries.map((entry) {
-        final index = entry.key;
         final e = entry.value;
-        final isLast = index == myInfo.exps.length - 1;
 
         return Row(
             crossAxisAlignment: CrossAxisAlignment.start,
@@ -41,7 +39,7 @@ class ExpView extends StatelessWidget {
                       padding: const EdgeInsets.symmetric(
                           horizontal: 10, vertical: 4),
                       decoration: BoxDecoration(
-                        color: AppColors.primary.withOpacity(0.1),
+                        color: AppColors.primary.withValues(alpha: 0.1),
                         borderRadius: BorderRadius.circular(12),
                       ),
                       child: Text(

--- a/lib/ui/footer.dart
+++ b/lib/ui/footer.dart
@@ -14,7 +14,7 @@ class Footer extends StatelessWidget {
     final mailto = Mailto(
       to: [AppConstants.mail],
     );
-    await launch('$mailto');
+    await launchUrl(Uri.parse('$mailto'));
   }
 
   getInTouch() => Column(
@@ -152,7 +152,7 @@ class Footer extends StatelessWidget {
                 ),
                 const SizedBox(height: 30),
                 Divider(
-                  color: AppColors.text.withOpacity(.75),
+                  color: AppColors.text.withValues(alpha: .75),
                   thickness: .5,
                 ),
                 const SizedBox(height: 20),
@@ -162,7 +162,7 @@ class Footer extends StatelessWidget {
                     Text(
                       'Proudly powered by Shine Wanna \u00a9${DateTime.now().year}',
                       style: TextStyle(
-                        color: AppColors.text.withOpacity(.75),
+                        color: AppColors.text.withValues(alpha: .75),
                       ),
                     ),
                     Row(children: _socialMedia()),
@@ -214,7 +214,7 @@ class Footer extends StatelessWidget {
                 ),
                 const SizedBox(height: 30),
                 Divider(
-                  color: AppColors.text.withOpacity(.75),
+                  color: AppColors.text.withValues(alpha: .75),
                   thickness: .5,
                 ),
                 const SizedBox(height: 20),
@@ -228,7 +228,7 @@ class Footer extends StatelessWidget {
                 Text(
                   'Proudly powered by Shine Wanna \u00a9${DateTime.now().year}',
                   style: TextStyle(
-                    color: AppColors.text.withOpacity(.75),
+                    color: AppColors.text.withValues(alpha: .75),
                   ),
                   textAlign: TextAlign.center,
                 ),
@@ -277,15 +277,15 @@ class _SocialIconState extends State<_SocialIcon> {
       onEnter: (_) => setState(() => _isHovered = true),
       onExit: (_) => setState(() => _isHovered = false),
       child: GestureDetector(
-        onTap: () => launch(widget.url),
+        onTap: () => launchUrl(Uri.parse(widget.url)),
         child: AnimatedContainer(
           duration: const Duration(milliseconds: 200),
           padding: const EdgeInsets.all(10),
           decoration: BoxDecoration(
             shape: BoxShape.circle,
             color: _isHovered
-                ? AppColors.primary.withOpacity(0.2)
-                : AppColors.primary.withOpacity(0.08),
+                ? AppColors.primary.withValues(alpha: 0.2)
+                : AppColors.primary.withValues(alpha: 0.08),
           ),
           child: AppIcon(widget.icon, size: 20),
         ),

--- a/lib/ui/header.dart
+++ b/lib/ui/header.dart
@@ -24,7 +24,7 @@ class Header extends StatelessWidget {
     return SliverAppBar(
       pinned: true,
       backgroundColor:
-          Theme.of(context).scaffoldBackgroundColor.withOpacity(0.95),
+          Theme.of(context).scaffoldBackgroundColor.withValues(alpha: 0.95),
       surfaceTintColor: Colors.transparent,
       title: Padding(
         padding: const EdgeInsets.only(left: 25.0),
@@ -105,7 +105,7 @@ class _MobileMenuButton extends StatelessWidget {
                     height: 4,
                     margin: const EdgeInsets.only(bottom: 16),
                     decoration: BoxDecoration(
-                      color: AppColors.primary.withOpacity(0.3),
+                      color: AppColors.primary.withValues(alpha: 0.3),
                       borderRadius: BorderRadius.circular(2),
                     ),
                   ),

--- a/lib/ui/home.dart
+++ b/lib/ui/home.dart
@@ -80,7 +80,7 @@ class _HomeState extends State<Home> {
         gradient: AppColors.primaryGradient,
         boxShadow: [
           BoxShadow(
-            color: AppColors.primary.withOpacity(0.3),
+            color: AppColors.primary.withValues(alpha: 0.3),
             blurRadius: 20,
             spreadRadius: 2,
           ),

--- a/lib/ui/language_view.dart
+++ b/lib/ui/language_view.dart
@@ -13,7 +13,7 @@ class LanguageView extends StatelessWidget {
       padding: const EdgeInsets.all(20),
       decoration: BoxDecoration(
         borderRadius: BorderRadius.circular(12),
-        border: Border.all(color: AppColors.primary.withOpacity(0.2)),
+        border: Border.all(color: AppColors.primary.withValues(alpha: 0.2)),
         color: AppColors.cardBackground,
       ),
       child: Column(
@@ -51,7 +51,7 @@ class LanguageView extends StatelessWidget {
                         width: 208.0,
                         lineHeight: 8.0,
                         percent: e.proficiency,
-                        backgroundColor: AppColors.primary.withOpacity(0.1),
+                        backgroundColor: AppColors.primary.withValues(alpha: 0.1),
                         linearGradient: AppColors.primaryGradient,
                         animation: true,
                         animationDuration: 1000,

--- a/lib/ui/projects.dart
+++ b/lib/ui/projects.dart
@@ -109,19 +109,19 @@ class Projects extends StatelessWidget {
                     ? Container(
                         height: 100,
                         decoration: BoxDecoration(
-                          color: AppColors.primary.withOpacity(0.1),
+                          color: AppColors.primary.withValues(alpha: 0.1),
                           borderRadius: BorderRadius.circular(12),
                         ),
                         child: Icon(
                           Icons.apps_rounded,
-                          color: AppColors.primary.withOpacity(0.5),
+                          color: AppColors.primary.withValues(alpha: 0.5),
                           size: 40,
                         ),
                       )
                     : GestureDetector(
                         onTap: project.playStore.isEmptyOrNull
                             ? null
-                            : () => launch(project.playStore!),
+                            : () => launchUrl(Uri.parse(project.playStore!)),
                         child: ClipRRect(
                           borderRadius: BorderRadius.circular(12),
                           child: Image.network(
@@ -140,12 +140,12 @@ class Projects extends StatelessWidget {
                                 Container(
                               height: 100,
                               decoration: BoxDecoration(
-                                color: AppColors.primary.withOpacity(0.1),
+                                color: AppColors.primary.withValues(alpha: 0.1),
                                 borderRadius: BorderRadius.circular(12),
                               ),
                               child: Icon(
                                 Icons.broken_image_outlined,
-                                color: AppColors.primary.withOpacity(0.5),
+                                color: AppColors.primary.withValues(alpha: 0.5),
                                 size: 40,
                               ),
                             ),
@@ -208,7 +208,7 @@ class Projects extends StatelessWidget {
                 child: GestureDetector(
                   onTap: project.playStore.isEmptyOrNull
                       ? null
-                      : () => launch(project.playStore!),
+                      : () => launchUrl(Uri.parse(project.playStore!)),
                   child: ClipRRect(
                     borderRadius: BorderRadius.circular(12),
                     child: Image.network(
@@ -224,12 +224,12 @@ class Projects extends StatelessWidget {
                       errorBuilder: (context, error, stack) => Container(
                         height: 80,
                         decoration: BoxDecoration(
-                          color: AppColors.primary.withOpacity(0.1),
+                          color: AppColors.primary.withValues(alpha: 0.1),
                           borderRadius: BorderRadius.circular(12),
                         ),
                         child: Icon(
                           Icons.broken_image_outlined,
-                          color: AppColors.primary.withOpacity(0.5),
+                          color: AppColors.primary.withValues(alpha: 0.5),
                           size: 30,
                         ),
                       ),

--- a/lib/ui/skill_view.dart
+++ b/lib/ui/skill_view.dart
@@ -42,9 +42,9 @@ class SkillView extends StatelessWidget {
                           decoration: BoxDecoration(
                             borderRadius: BorderRadius.circular(20),
                             border: Border.all(
-                              color: AppColors.primary.withOpacity(0.3),
+                              color: AppColors.primary.withValues(alpha: 0.3),
                             ),
-                            color: AppColors.primary.withOpacity(0.08),
+                            color: AppColors.primary.withValues(alpha: 0.08),
                           ),
                           child: Text(
                             e.name,

--- a/lib/ui/store_button.dart
+++ b/lib/ui/store_button.dart
@@ -29,26 +29,26 @@ class StoreButton extends StatelessWidget {
     _buildButton(Button button) => button.url.isEmptyOrNull
         ? Nth()
         : OutlinedButton(
-            onPressed: () => launch(button.url!),
+            onPressed: () => launchUrl(Uri.parse(button.url!)),
             style: ButtonStyle(
-              side: MaterialStateProperty.resolveWith<BorderSide>((states) {
+              side: WidgetStateProperty.resolveWith<BorderSide>((states) {
                 return BorderSide(
-                  color: button.color.withOpacity(.5),
+                  color: button.color.withValues(alpha: .5),
                   width: 5,
                 );
               }),
-              padding: MaterialStateProperty.all<EdgeInsetsGeometry>(
+              padding: WidgetStateProperty.all<EdgeInsetsGeometry>(
                 EdgeInsets.symmetric(
                   horizontal: horPad,
                   vertical: verPad,
                 ),
               ),
-              shape: MaterialStateProperty.all<OutlinedBorder>(
+              shape: WidgetStateProperty.all<OutlinedBorder>(
                 RoundedRectangleBorder(
                   borderRadius: BorderRadius.circular(20),
                 ),
               ),
-              textStyle: MaterialStateProperty.all<TextStyle>(
+              textStyle: WidgetStateProperty.all<TextStyle>(
                 TextStyle(color: Colors.black),
               ),
             ),

--- a/lib/widget/line_box_widget.dart
+++ b/lib/widget/line_box_widget.dart
@@ -18,7 +18,7 @@ class LineBoxWidget extends StatelessWidget {
             height: 1,
             decoration: BoxDecoration(
               gradient: LinearGradient(
-                colors: [color.withOpacity(0), color],
+                colors: [color.withValues(alpha: 0), color],
               ),
             ),
           ),
@@ -66,7 +66,7 @@ class LineBoxWidget extends StatelessWidget {
             height: 1,
             decoration: BoxDecoration(
               gradient: LinearGradient(
-                colors: [color, color.withOpacity(0)],
+                colors: [color, color.withValues(alpha: 0)],
               ),
             ),
           ),

--- a/lib/widget/shimmer_placeholder.dart
+++ b/lib/widget/shimmer_placeholder.dart
@@ -50,9 +50,9 @@ class _ShimmerPlaceholderState extends State<ShimmerPlaceholder>
               begin: Alignment(-1.0 + 2.0 * _controller.value, 0),
               end: Alignment(-1.0 + 2.0 * _controller.value + 1.0, 0),
               colors: [
-                AppColors.primary.withOpacity(0.06),
-                AppColors.primary.withOpacity(0.14),
-                AppColors.primary.withOpacity(0.06),
+                AppColors.primary.withValues(alpha: 0.06),
+                AppColors.primary.withValues(alpha: 0.14),
+                AppColors.primary.withValues(alpha: 0.06),
               ],
             ),
           ),


### PR DESCRIPTION
## Summary
- Replace deprecated `withOpacity()` with `withValues(alpha:)` across all UI files
- Replace deprecated `launch()` with `launchUrl(Uri.parse())` in url_launcher usages
- Replace deprecated `AppBarTheme(color:)` with `backgroundColor` in main.dart
- Replace deprecated `MaterialStateProperty` with `WidgetStateProperty` in store_button.dart
- Remove unused local variable `isLast` in exp_view.dart

## Test plan
- [ ] Run `dart analyze` — should report **No issues found**
- [ ] Verify app builds and runs correctly on web

🤖 Generated with [Claude Code](https://claude.com/claude-code)